### PR TITLE
Made public path configurable with env variables

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  publicPath: '/',
+  publicPath: process.env.NODE_ENV === 'production' ? process.env.PUBLIC_PATH || '/' : '/',
   pwa: {
     name: 'Coffee Scale',
     themeColor: '#528078',

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production' ? '/coffee/' : '/',
+  publicPath: '/',
   pwa: {
     name: 'Coffee Scale',
     themeColor: '#528078',


### PR DESCRIPTION
Setting the PUBLIC_PATH env variable allows to build for serving from a subfolder.