### PR TITLE
feat: add support for new firmware

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "coffee-scale-app",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,7 +586,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.22.2
-      caniuse-lite: 1.0.30001566
+      caniuse-lite: 1.0.30001568
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -632,8 +632,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001566
-      electron-to-chromium: 1.4.608
+      caniuse-lite: 1.0.30001568
+      electron-to-chromium: 1.4.609
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
     dev: true
@@ -652,8 +652,8 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
-  /caniuse-lite@1.0.30001566:
-    resolution: {integrity: sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==}
+  /caniuse-lite@1.0.30001568:
+    resolution: {integrity: sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==}
     dev: true
 
   /chart.js@4.4.1:
@@ -788,8 +788,8 @@ packages:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
     dev: true
 
-  /electron-to-chromium@1.4.608:
-    resolution: {integrity: sha512-J2f/3iIIm3Mo0npneITZ2UPe4B1bg8fTNrFjD8715F/k1BvbviRuqYGkET1PgprrczXYTHFvotbBOmUp6KE0uA==}
+  /electron-to-chromium@1.4.609:
+    resolution: {integrity: sha512-ihiCP7PJmjoGNuLpl7TjNA8pCQWu09vGyjlPYw1Rqww4gvNuCcmvl+44G+2QyJ6S2K4o+wbTS++Xz0YN8Q9ERw==}
     dev: true
 
   /es6-promise@3.3.1:

--- a/src/lib/bt.ts
+++ b/src/lib/bt.ts
@@ -36,7 +36,12 @@ export async function connectBt() {
 		return
 	}
 	const device = await navigator.bluetooth.requestDevice({
-		filters: [{ name: 'mpy-coffee' }, { services: [parseInt('0x1815'), parseInt('0x180F')] }],
+		filters: [
+			{ name: 'mpy-coffee' },
+			{ name: 'coffee-scale' },
+			{ services: [parseInt('0x180F'), parseInt('0x1815')] }, // python firmware
+			{ services: [parseInt('0x180F'), parseInt('0x181D')] }, // rust firmware
+		],
 	})
 	device.addEventListener('gattserverdisconnected', () => {
 		btConnected.set(false)
@@ -46,10 +51,21 @@ export async function connectBt() {
 	const server = await device.gatt?.connect()
 	btConnected.set(true)
 	btServer.set(server ?? null)
-	const service = await server?.getPrimaryService(parseInt('0x1815'))
-	weightCharacteristic = (await service?.getCharacteristic(parseInt('0x2A59'))) ?? null
-	await weightCharacteristic?.startNotifications()
-	weightCharacteristic?.addEventListener('characteristicvaluechanged', onWeightUpdate)
+
+	try {
+		// python firmware
+		const service = await server?.getPrimaryService(parseInt('0x1815'))
+		weightCharacteristic = (await service?.getCharacteristic(parseInt('0x2A59'))) ?? null
+		await weightCharacteristic?.startNotifications()
+		weightCharacteristic?.addEventListener('characteristicvaluechanged', onWeightUpdate)
+	} catch {
+		// rust firmware
+		const service = await server?.getPrimaryService(parseInt('0x181D'))
+		weightCharacteristic = (await service?.getCharacteristic(parseInt('0x2A9D'))) ?? null
+		await weightCharacteristic?.startNotifications()
+		weightCharacteristic?.addEventListener('characteristicvaluechanged', onWeightUpdate)
+	}
+
 	await readBatteryLevel()
 	if ('wakeLock' in navigator) {
 		try {


### PR DESCRIPTION
This PR adds support for the new sensor UUID and device name that will be used in the Rust firmware. The micropython firmware is still supported.